### PR TITLE
added more randomness to dithering behavior to get rid of sweeping effect

### DIFF
--- a/src/Classes/DitherManager.cpp
+++ b/src/Classes/DitherManager.cpp
@@ -19,6 +19,11 @@ DitherManager::DitherManager()
     _frameArray[i] = i;
   }
   randomize(_frameArray, DITHER_LEVEL);
+  for (int i = 0; i < NUM_LEDS; i++)
+  {
+    _idxArray[i] = i;
+  }
+  randomize(_idxArray, NUM_LEDS);
 }
 
 inline int DitherManager::ditherSingle(int idx, int brightness, int high_frames)
@@ -29,9 +34,9 @@ inline int DitherManager::ditherSingle(int idx, int brightness, int high_frames)
 inline void DitherManager::dithering(int idx, int r, int r_high_frames, int g, int g_high_frames, int b, int b_high_frames)
 {
   _leds[idx].setRGB(
-      ditherSingle((idx) % DITHER_LEVEL, r, r_high_frames),
-      ditherSingle((idx + _greenOffset) % DITHER_LEVEL, g, g_high_frames),
-      ditherSingle((idx + _blueOffset) % DITHER_LEVEL, b, b_high_frames));
+      ditherSingle(_idxArray[idx], r, r_high_frames),
+      ditherSingle(_idxArray[(idx + _greenOffset) % DITHER_LEVEL], g, g_high_frames),
+      ditherSingle(_idxArray[(idx + _blueOffset) % DITHER_LEVEL], b, b_high_frames));
   // _leds[idx].setRGB(1,1,1);
 }
 

--- a/src/Classes/DitherManager.h
+++ b/src/Classes/DitherManager.h
@@ -7,6 +7,7 @@ private:
     static const int _greenOffset = (DITHER_LEVEL / 3);
     static const int _blueOffset = (DITHER_LEVEL / 3) * 2.0;
     int _frameArray[DITHER_LEVEL];
+    int _idxArray[NUM_LEDS];
     CLEDController *pCur = CLEDController::head();
 
     int _frame = 0;


### PR DESCRIPTION
Before this change there were more often contiguous sections of the led matrix that showed the same value on a given frame. For example if the brightness was right in between two values have of the grid will be set to the high and the other half set to low. Before this change a contiguous section of leds would be set to high because the logic for determining a led's brightness is determined by it's index. Now the real index for an led is looked up in a randomized array to determine if it should be set high or not.